### PR TITLE
feat: initialize geolonia-template-library

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/guard.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/post-tool-format.sh \"$FILE_PATH\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/code-review-expert/SKILL.md
+++ b/.claude/skills/code-review-expert/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: code-review-expert
+description: "Expert automated code review with SOLID, security, and quality checks. Supports --auto mode for CI/pre-push hooks. Use /code-review-expert or /code-review-expert --auto"
+license: MIT
+tags:
+  - code-review
+  - security
+  - solid
+  - automation
+  - quality
+---
+
+# Code Review Expert
+
+## Overview
+
+Perform a structured review of the current git changes with focus on SOLID, architecture, removal candidates, and security risks. Default to review-only output unless the user asks to implement changes.
+
+## Severity Levels
+
+| Level | Name | Description | Action |
+|-------|------|-------------|--------|
+| **P0** | Critical | Security vulnerability, data loss risk, correctness bug | Must block merge |
+| **P1** | High | Logic error, significant SOLID violation, performance regression | Should fix before merge |
+| **P2** | Medium | Code smell, maintainability concern, minor SOLID violation | Fix in this PR or create follow-up |
+| **P3** | Low | Style, naming, minor suggestion | Optional improvement |
+
+## Workflow
+
+### 1) Preflight context
+
+- Use `git status -sb`, `git diff --stat`, and `git diff` to scope changes.
+- If needed, use `rg` or `grep` to find related modules, usages, and contracts.
+- Identify entry points, ownership boundaries, and critical paths (auth, payments, data writes, network).
+
+### 1.5) Automated lint & typecheck (MANDATORY)
+
+Run the project's lint and typecheck commands **before** starting the manual review.
+
+**Execution order**:
+1. **Typecheck**: `npm run typecheck` or `pnpm run typecheck`
+2. **Lint**: `npm run lint` or `pnpm run lint`
+
+**Rules**:
+- If either command **fails**, report all errors as **P1 findings**.
+- If both **pass**, note "Typecheck: PASS, Lint: PASS" in the review summary.
+
+### 2) SOLID + architecture smells
+
+Look for:
+- **SRP**: Overloaded modules with unrelated responsibilities.
+- **OCP**: Frequent edits to add behavior instead of extension points.
+- **LSP**: Subclasses that break expectations or require type checks.
+- **ISP**: Wide interfaces with unused methods.
+- **DIP**: High-level logic tied to low-level implementations.
+
+### 3) Removal candidates
+
+Identify code that is unused, redundant, or feature-flagged off.
+
+### 4) Security and reliability scan
+
+Check for:
+- XSS, injection (SQL/NoSQL/command), SSRF, path traversal
+- AuthZ/AuthN gaps, missing tenancy checks
+- Secret leakage or API keys in logs/env/files
+- Rate limits, unbounded loops, CPU/memory hotspots
+- Unsafe deserialization, weak crypto, insecure defaults
+
+### 5) Code quality scan
+
+Check for:
+- **Error handling**: swallowed exceptions, missing async error handling
+- **Performance**: N+1 queries, unbounded memory, missing cache
+- **Boundary conditions**: null/undefined, empty collections, numeric boundaries
+
+### 6) Output format
+
+**Check `--auto` flag FIRST to decide output format.**
+
+#### Auto mode output (--auto flag present):
+
+```
+Review: X files, Y lines | Typecheck: PASS/FAIL | Lint: PASS/FAIL
+P0: 0 | P1: 0 | P2: N | P3: N
+[If P0/P1 exist, list ONLY those — one line each: file:line — description]
+```
+
+Maximum 10 lines. No P2/P3 details, no markdown headers.
+
+#### Interactive mode output (no --auto flag):
+
+```markdown
+## Code Review Summary
+
+**Files reviewed**: X files, Y lines changed
+**Overall assessment**: [APPROVE / REQUEST_CHANGES / COMMENT]
+
+## Findings
+
+### P0 - Critical
+(none or list)
+
+### P1 - High
+- **[file:line]** Brief title
+  - Description of issue
+  - Suggested fix
+
+### P2 - Medium
+...
+
+### P3 - Low
+...
+```
+
+### 7) Next steps — AUTO vs INTERACTIVE
+
+#### If `--auto` IS present (auto mode):
+
+1. If P0 or P1 issues exist -> fix them immediately, no questions asked
+2. If NO P0/P1 issues -> output the summary
+3. Do NOT use AskUserQuestion under any circumstances
+4. Do NOT wait for user input
+5. After the review, immediately continue with remaining workflow steps
+
+#### If `--auto` is NOT present (interactive mode):
+
+After presenting findings, ask user how to proceed:
+
+```
+How would you like to proceed?
+1. Fix all
+2. Fix P0/P1 only
+3. Fix specific items
+4. No changes — review complete
+```
+
+Do NOT implement any changes until user explicitly confirms.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS
+# Default owner for all files
+# Replace @geolonia/your-team with the actual team slug.
+* @geolonia/platform
+
+# Critical configuration files require platform team review
+# WHY: These files define quality standards. Changes need extra scrutiny.
+biome.json @geolonia/platform
+tsconfig.json @geolonia/platform
+lefthook.yml @geolonia/platform
+catalog-info.yaml @geolonia/platform
+.github/workflows/ @geolonia/platform

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      production-dependencies:
+        dependency-type: "production"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [main, "feat/**", "fix/**", "chore/**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Typecheck, Lint, Test, Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Build
+        run: pnpm run build
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+coverage/
+*.d.ts.map
+.env
+.env.local
+.env.*.local
+.code-review-done

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+approve-builds=@biomejs/biome,esbuild,lefthook

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md
+
+> Agent-agnostic instructions for Claude Code, Codex, Cursor, Copilot, and other coding agents.
+> See CLAUDE.md for Claude Code-specific settings.
+
+## Tech Stack
+
+| Tool | Purpose | Why |
+|------|---------|-----|
+| Node.js 22+ | Runtime | LTS with native ESM, top-level await |
+| TypeScript 5+ (strict) | Language | Type safety, better tooling, prevents `any` abuse |
+| pnpm | Package manager | Faster installs, disk-efficient, strict dependency resolution |
+| Biome | Lint + Format | 10-25x faster than ESLint+Prettier. Single tool, no config conflicts |
+| Vitest | Testing | Native ESM, fast, Vite-powered |
+| Lefthook | Git hooks | Go binary, fast, parallel execution |
+
+## Build & Test Commands
+
+```bash
+pnpm install          # Install dependencies
+pnpm run build        # Compile TypeScript → dist/
+pnpm run typecheck    # Type check without emit
+pnpm run lint         # Biome lint check
+pnpm run lint:fix     # Biome lint + auto-fix
+pnpm run format       # Biome format
+pnpm run test         # Vitest run (single pass)
+pnpm run test:watch   # Vitest watch mode
+```
+
+## Architecture
+
+- `src/` — Source code (TypeScript)
+- `tests/` — Tests mirror the structure of `src/`
+- `dist/` — Compiled output (generated, git-ignored)
+- `docs/decisions/` — Architecture Decision Records (ADRs)
+
+## Coding Conventions
+
+### Branch Naming
+```
+feat/<description>    # New features
+fix/<description>     # Bug fixes
+chore/<description>   # Maintenance, deps
+docs/<description>    # Documentation only
+```
+
+### Commit Messages (Conventional Commits)
+```
+feat: add new export function
+fix: correct edge case in parser
+chore: update dependencies
+docs: improve README
+```
+
+### PR Rules
+- Small PRs (< 400 lines diff) preferred
+- Each PR must have a linked GitHub Issue (`Closes #N`)
+- All CI checks must pass before merge
+- CodeRabbit review required
+
+## Code Style
+
+All style rules are enforced by **Biome** (`biome.json`). Do not modify `biome.json` to suppress errors.
+
+Key rules:
+- `any` is **forbidden** (`noExplicitAny: error`)
+- Non-null assertions (`!`) are **forbidden** (`noNonNullAssertion: error`)
+- All imports must be used (`noUnusedImports: error`)
+- Use `const` over `let` when possible (`useConst: error`)
+
+## Testing
+
+- **Test-first**: Write tests before implementation
+- **Mirror structure**: `src/foo/bar.ts` → `tests/foo/bar.test.ts`
+- **Coverage**: All public exports must have tests
+- **No skipping**: Skipped tests = incomplete tests
+
+## Security
+
+- Never commit `.env` or secrets
+- Run `pnpm audit` before releasing
+- No `eval`, `innerHTML`, `dangerouslySetInnerHTML`
+- Review OWASP Top 10 for applicable risks
+
+## Prohibited Actions
+
+Do NOT modify these files (see guard.sh Hook 5):
+- `biome.json` — Lint/format config
+- `tsconfig.json` — TypeScript config
+- `lefthook.yml` — Git hooks config
+- `.github/workflows/` — CI/CD pipelines
+- `catalog-info.yaml` — ISMS metadata
+- `CODEOWNERS` — Review requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial template structure for Geolonia TypeScript library development
+- TypeScript 5 strict mode configuration (`tsconfig.json`)
+- Biome for linting and formatting (`biome.json`) — see ADR-0001
+- Lefthook for Git hooks (`lefthook.yml`) — see ADR-0002
+- Vitest for testing
+- Claude Code Hooks:
+  - `scripts/hooks/guard.sh` (PreToolUse: Hook 2-5)
+  - `scripts/hooks/post-tool-format.sh` (PostToolUse: auto-format)
+- `.claude/settings.json` for Claude Code hook configuration
+- `.claude/skills/code-review-expert/SKILL.md` (generic version)
+- `AGENTS.md` for agent-agnostic instructions
+- `CLAUDE.md` for Claude Code-specific settings (50 lines)
+- `catalog-info.yaml` for Backstage + ISMS compliance
+- `.github/workflows/ci.yml` for CI/CD
+- `.github/CODEOWNERS` for code review requirements
+- `.github/dependabot.yml` for automated dependency updates
+- `docs/decisions/` with ADR template and initial ADRs
+- `src/index.ts` and `tests/index.test.ts` as starter files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+> See AGENTS.md for agent-agnostic instructions (build commands, conventions, architecture).
+> This file contains Claude Code-specific settings only.
+
+## Claude Code Hooks
+
+Two hooks protect code quality automatically:
+
+| Hook | File | Trigger | Purpose |
+|------|------|---------|---------|
+| PreToolUse | `scripts/hooks/guard.sh` | Before Bash/Write/Edit | Block destructive ops + main branch protection + config file protection |
+| PostToolUse | `scripts/hooks/post-tool-format.sh` | After Write/Edit | Auto-format with Biome |
+
+**WHY hooks**: Provides ms-level feedback (Layer 1 of the 4-layer quality model). Catches issues before they reach pre-commit (seconds) or CI (minutes).
+
+### guard.sh Protections
+
+- **Hook 2**: Blocks destructive operations (rm -rf, force push, reset --hard, etc.)
+- **Hook 3**: Blocks direct commit/push to `main`/`master` — always use a branch
+- **Hook 4**: Runs typecheck + lint before push
+- **Hook 5**: Blocks agent modification of config files (biome.json, tsconfig.json, etc.)
+
+### Disabling Hooks (for legitimate use)
+
+To temporarily disable for human-initiated work:
+```bash
+# Remove or rename .claude/settings.json temporarily
+mv .claude/settings.json .claude/settings.json.bak
+# ... do your work ...
+mv .claude/settings.json.bak .claude/settings.json
+```
+
+## Code Review
+
+Use the built-in skill before pushing:
+```
+/code-review-expert --auto
+```
+
+See `.claude/skills/code-review-expert/SKILL.md` for details.
+
+## Workflow
+
+1. Non-trivial changes: Use Plan Mode first (`/plan`)
+2. Write tests before implementation
+3. For changes touching >3 files: create a plan and get approval
+4. Run `/code-review-expert --auto` before every push
+
+## Project-Specific Notes
+
+<!-- Add project-specific notes here after cloning the template -->
+<!-- Keep total CLAUDE.md under 50 lines -->
+<!-- Example:
+## API Keys
+- SOME_API_KEY: Used for X. See .env.sample for setup.
+-->

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Geolonia Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,314 @@
+# geolonia-template-library
+
+Geolonia TypeScript ライブラリ開発の標準テンプレート。
+新規リポジトリを作成する際にこのテンプレートを clone し、すぐに開発を始められる状態を提供します。
+
+## Features
+
+- **TypeScript strict** — `any` 禁止、null チェック厳格化
+- **Biome** — ESLint+Prettier の代替。10-25x 高速 ([ADR-0001](docs/decisions/0001-use-biome.md))
+- **Lefthook** — Git hooks。コミット前に自動 lint/typecheck ([ADR-0002](docs/decisions/0002-use-lefthook.md))
+- **Vitest** — 高速テストランナー
+- **Claude Code Hooks** — AI エージェントの品質ゲート (guard.sh)
+- **code-review-expert** — プッシュ前のコードレビュースキル
+- **Backstage + ISMS** — `catalog-info.yaml` でコンプライアンス対応
+
+---
+
+## Getting Started
+
+### 1. Clone & Rename
+
+```bash
+# GitHub の "Use this template" ボタンを使うか、直接 clone する
+git clone https://github.com/geolonia/geolonia-template-library.git your-library-name
+cd your-library-name
+
+# 新しいリポジトリとして初期化
+rm -rf .git
+git init
+git checkout -b main
+```
+
+### 2. Customize
+
+以下のファイルを実際のプロジェクト情報に更新してください:
+
+| ファイル | 変更箇所 |
+|--------|--------|
+| `package.json` | `name`, `description`, `version` |
+| `catalog-info.yaml` | `{{PROJECT_NAME}}`, `{{TEAM}}`, `{{SYSTEM}}` 等のプレースホルダー |
+| `CODEOWNERS` | `@geolonia/your-team` のチームスラッグ |
+| `CLAUDE.md` | プロジェクト固有のメモ（50行以内を維持） |
+| `README.md` | このファイル自体 |
+
+### 3. Initial Setup
+
+```bash
+# 依存関係のインストール
+pnpm install
+
+# Git hooks のインストール (Lefthook)
+npx lefthook install
+
+# 動作確認
+pnpm run typecheck  # TypeScript 型チェック
+pnpm run lint       # Biome lint
+pnpm run test       # Vitest テスト
+pnpm run build      # ビルド確認
+```
+
+### 4. Create First Commit
+
+```bash
+git add -A
+git commit -m "chore: initialize from geolonia-template-library"
+git remote add origin https://github.com/geolonia/your-library-name.git
+git push -u origin main
+```
+
+### 5. Setup GitHub
+
+- **Dependabot**: リポジトリ設定 → Security → Dependabot alerts を有効化
+- **Secret Scanning**: リポジトリ設定 → Security → Secret scanning を有効化
+- **Branch Protection**: `main` ブランチに PR required + CI required を設定
+- **CODEOWNERS**: `.github/CODEOWNERS` のチームを実際のチームに更新
+
+---
+
+## Directory Structure
+
+```
+.
+├── .claude/
+│   ├── settings.json          # Claude Code hooks 設定
+│   └── skills/
+│       └── code-review-expert/
+│           └── SKILL.md       # /code-review-expert スキル
+├── .github/
+│   ├── workflows/
+│   │   └── ci.yml             # CI/CD パイプライン
+│   ├── CODEOWNERS             # レビュー必須メンバー設定
+│   └── dependabot.yml         # 依存関係自動更新
+├── docs/
+│   └── decisions/             # Architecture Decision Records
+│       ├── 0000-template.md   # ADR 書き方テンプレート
+│       ├── 0001-use-biome.md  # なぜ Biome を採用したか
+│       └── 0002-use-lefthook.md  # なぜ Lefthook を採用したか
+├── scripts/
+│   └── hooks/
+│       ├── guard.sh           # PreToolUse hook (安全ガード)
+│       └── post-tool-format.sh  # PostToolUse hook (自動フォーマット)
+├── src/
+│   └── index.ts               # ライブラリエントリーポイント
+├── tests/
+│   └── index.test.ts          # テスト (src/ と同じ構造)
+├── AGENTS.md                  # エージェント共通指示
+├── CHANGELOG.md               # 変更履歴
+├── CLAUDE.md                  # Claude Code 固有設定
+├── LICENSE                    # MIT License
+├── README.md                  # このファイル
+├── biome.json                 # Biome 設定 (lint + format)
+├── catalog-info.yaml          # Backstage + ISMS メタデータ
+├── lefthook.yml               # Git hooks 設定
+├── package.json               # npm パッケージ設定
+└── tsconfig.json              # TypeScript コンパイラ設定
+```
+
+---
+
+## Tools
+
+### Biome (Lint + Format)
+
+ESLint + Prettier の代替。Rust 製で 10-25x 高速。
+
+```bash
+pnpm run lint        # lint チェック
+pnpm run lint:fix    # lint + 自動修正
+pnpm run format      # フォーマット
+```
+
+設定: `biome.json`
+
+主なルール:
+- `noExplicitAny: error` — `any` 型は禁止
+- `noNonNullAssertion: error` — `!` 演算子は禁止
+- `noUnusedImports: error` — 未使用 import は禁止
+
+設定変更が必要な場合はチームレビュー + ADR 作成が必要です (`CODEOWNERS` 参照)。
+
+### Lefthook (Git Hooks)
+
+コミット前・プッシュ前の自動チェック。
+
+```yaml
+# lefthook.yml の動作
+pre-commit:
+  - biome format (自動修正)
+  - biome check (lint)
+  - tsc --noEmit (型チェック)
+
+pre-push:
+  - tsc --noEmit
+  - biome check
+  - vitest run (テスト)
+```
+
+初回セットアップ: `npx lefthook install`
+
+### Vitest (Testing)
+
+```bash
+pnpm run test        # 全テストを1回実行
+pnpm run test:watch  # ウォッチモード
+```
+
+テストは `tests/` に配置し、`src/` と同じディレクトリ構造にしてください。
+例: `src/foo/bar.ts` → `tests/foo/bar.test.ts`
+
+---
+
+## Claude Code Hooks
+
+### guard.sh (PreToolUse)
+
+Claude Code 等の AI エージェントが実行する操作を自動的にチェックします。
+
+| Hook | 内容 |
+|------|------|
+| Hook 2 | 破壊的操作のブロック (rm -rf, force push 等) |
+| Hook 3 | `main`/`master` への直接コミット・プッシュをブロック |
+| Hook 4 | プッシュ前に typecheck + lint を自動実行 |
+| Hook 5 | `biome.json`, `tsconfig.json` 等の設定ファイルの変更をブロック |
+
+**設定ファイル保護 (Hook 5) の対象:**
+- `biome.json` — lint/format ルール
+- `tsconfig.json` — TypeScript 設定
+- `lefthook.yml` — Git hooks
+- `.github/workflows/` — CI/CD
+- `catalog-info.yaml` — ISMS メタデータ
+- `CODEOWNERS` — レビュー要件
+
+#### フックを一時的に無効化する方法
+
+人間が作業で一時的に無効化が必要な場合:
+
+```bash
+mv .claude/settings.json .claude/settings.json.bak
+# 作業...
+mv .claude/settings.json.bak .claude/settings.json
+```
+
+### post-tool-format.sh (PostToolUse)
+
+`Write` または `Edit` ツール実行後に自動でフォーマットします。
+Claude Code がファイルを書いた直後に Biome が走り、フォーマットのずれを即座に修正します。
+
+### code-review-expert スキル
+
+```
+/code-review-expert          # インタラクティブモード
+/code-review-expert --auto   # 自動修正モード (CI/push前推奨)
+```
+
+プッシュ前に必ず実行することを推奨します。
+
+---
+
+## CI/CD
+
+### GitHub Actions (ci.yml)
+
+| イベント | ジョブ |
+|--------|-------|
+| PR → main | typecheck + lint + test + build |
+| tag push (v*.*.*) | 上記 + npm publish |
+
+### npm 公開
+
+1. `package.json` の `version` を更新
+2. `CHANGELOG.md` を更新
+3. `git tag v1.0.0 && git push origin v1.0.0`
+4. GitHub Actions が自動的に npm publish
+
+npm 公開には `NPM_TOKEN` シークレットの設定が必要です (GitHub リポジトリ設定 → Secrets)。
+
+---
+
+## catalog-info.yaml 記入ガイド
+
+Backstage カタログ登録 + ISMS コンプライアンスのためのメタデータファイルです。
+
+### 必須フィールド
+
+| フィールド | 例 | 説明 |
+|---------|---|-----|
+| `metadata.name` | `my-library` | リポジトリ名と同じ（小文字・ハイフン） |
+| `spec.owner` | `group:geolonia/platform` | 担当チーム |
+| `spec.system` | `geolonia-developer-platform` | 所属する上位システム |
+
+### ISMS アノテーション
+
+| アノテーション | 値 | 意味 |
+|-------------|---|-----|
+| `geolonia.com/data-classification` | `none` / `internal` / `confidential` / `restricted` | 扱うデータの機密度 |
+| `geolonia.com/backup-required` | `true` / `false` | 定期バックアップが必要か |
+| `geolonia.com/regulatory-scope` | `none` / `pii` / `payment` | 規制対象データの種類 |
+
+詳細は `catalog-info.yaml` 内のコメントと [ISMS Issue #93](https://github.com/geolonia/geolonia-backstage/issues/93) を参照。
+
+---
+
+## Architecture Decisions (ADRs)
+
+設計上の重要な決定は `docs/decisions/` に記録します。
+
+| ADR | 内容 |
+|-----|-----|
+| [ADR-0000](docs/decisions/0000-template.md) | ADR 書き方テンプレート |
+| [ADR-0001](docs/decisions/0001-use-biome.md) | Biome 採用理由 |
+| [ADR-0002](docs/decisions/0002-use-lefthook.md) | Lefthook 採用理由 |
+
+新しい技術的決定は ADR として記録してください。テンプレートは `docs/decisions/0000-template.md`。
+
+---
+
+## FAQ
+
+### Q: Biome に未対応の ESLint ルールが必要になった場合は？
+
+CI 層 (`.github/workflows/ci.yml`) に Oxlint または Semgrep を追加してください。
+PostToolUse/pre-commit 層は Biome のみで十分です（速度優先）。
+
+### Q: `pnpm run lint` が設定ファイルにエラーを報告する
+
+guard.sh の Hook 5 が保護するファイルは人間が手動で変更してください。
+変更の理由は ADR として記録することを推奨します。
+
+### Q: Lefthook のフックをスキップしたい
+
+```bash
+git commit --no-verify  # pre-commit をスキップ
+git push --no-verify    # pre-push をスキップ
+```
+
+緊急時のみ使用してください。CI は必ず通す必要があります。
+
+### Q: npm publish するには何が必要？
+
+1. `NPM_TOKEN` を GitHub シークレットに設定
+2. `package.json` の `name` を `@geolonia/your-actual-name` に変更
+3. npm org メンバーシップの確認
+
+### Q: このテンプレートのアップデートを受け取るには？
+
+[geolonia-template-library](https://github.com/geolonia/geolonia-template-library) のリリースを Watch してください。
+変更は CHANGELOG.md で確認できます。
+手動でのマージが必要ですが、`@geolonia/config` パッケージ（将来実装予定）で設定の自動更新を予定しています。
+
+---
+
+## License
+
+MIT © [Geolonia Inc.](https://geolonia.com)

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "error",
+        "noConsole": "warn"
+      },
+      "style": {
+        "useConst": "error",
+        "useTemplate": "error",
+        "noNonNullAssertion": "error"
+      },
+      "security": {
+        "noGlobalEval": "error"
+      }
+    }
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["dist", "node_modules", "coverage", "*.d.ts"]
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all"
+    }
+  }
+}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,103 @@
+# catalog-info.yaml — Backstage Entity Definition
+#
+# このファイルは Backstage カタログに登録するためのメタデータです。
+# 新しいリポジトリを作成したら、以下の {{PLACEHOLDER}} を実際の値に置き換えてください。
+# ISMS（情報セキュリティ管理システム）との連携にも使用されます。
+#
+# 詳細: https://github.com/geolonia/geolonia-backstage
+# ISMS統合: https://github.com/geolonia/geolonia-backstage/issues/93
+
+# Backstage API バージョン。v1alpha1 が現在の標準。
+apiVersion: backstage.io/v1alpha1
+
+# エンティティの種類。
+# - Component: ソフトウェアコンポーネント（ライブラリ、サービス、Web サイト等）
+# - System: 複数の Component をまとめる論理グループ
+# - API: 公開 API 定義
+# - Resource: データベース、S3バケット等のインフラリソース
+kind: Component
+
+metadata:
+  # リポジトリ名と同じ名前を推奨（小文字、ハイフン区切り）
+  # 例: geolonia-template-library
+  name: "{{PROJECT_NAME}}"
+
+  # 人が読むための表示名（日本語可）
+  # 例: "Geolonia TypeScript Library Template"
+  title: "{{DISPLAY_NAME}}"
+
+  # このコンポーネントの1行説明
+  # 例: "Geolonia TypeScript ライブラリ開発の標準テンプレート"
+  description: "{{DESCRIPTION}}"
+
+  annotations:
+    # GitHub リポジトリとの紐付け（必須）
+    # 形式: {org}/{repo}
+    # 例: geolonia/geolonia-template-library
+    github.com/project-slug: "geolonia/{{PROJECT_NAME}}"
+
+    # ISMS: データ分類
+    # none: 公開情報のみ
+    # internal: 社内情報
+    # confidential: 機密情報
+    # restricted: 最機密情報
+    # 例: internal
+    geolonia.com/data-classification: "none"
+
+    # ISMS: バックアップ要否
+    # true: 定期バックアップが必要（本番データを扱う場合）
+    # false: バックアップ不要（コードのみ）
+    # 例: false
+    geolonia.com/backup-required: "false"
+
+    # ISMS: 規制対象
+    # pii: 個人情報を扱う
+    # payment: 決済情報を扱う
+    # none: 規制対象外
+    # 例: none
+    geolonia.com/regulatory-scope: "none"
+
+  # 検索・フィルタリング用タグ
+  # 例: ["typescript", "library", "sdk"]
+  tags:
+    - typescript
+    - library
+
+  # 関連リンク（ドキュメント、Slack チャンネル等）
+  links:
+    - url: "https://github.com/geolonia/{{PROJECT_NAME}}"
+      title: GitHub Repository
+
+spec:
+  # コンポーネント種別
+  # library: npm パッケージ / SDK
+  # service: API サーバー、バックエンドサービス
+  # website: Web フロントエンド
+  # documentation: ドキュメントサイト
+  type: library
+
+  # ライフサイクル
+  # experimental: 試験的、本番利用前
+  # production: 本番稼働中
+  # deprecated: 非推奨、移行先あり
+  lifecycle: experimental
+
+  # オーナー（必須）
+  # Backstage の Group または User を指定
+  # 形式: group:{group-slug} または user:{username}
+  # 例: group:geolonia/platform
+  owner: "group:geolonia/{{TEAM}}"
+
+  # 所属するシステム（必須 — ISMS コンプライアンスに必要）
+  # このコンポーネントが属する上位 System を指定
+  # System 一覧: https://github.com/geolonia/geolonia-backstage （要確認）
+  # 例: geolonia-developer-platform
+  system: "{{SYSTEM}}"
+
+  # このコンポーネントが依存するコンポーネント一覧
+  # 例: ["component:default/other-library"]
+  dependsOn: []
+
+  # このコンポーネントが提供する API 一覧
+  # 例: ["api:default/my-api"]
+  providesApis: []

--- a/docs/decisions/0000-template.md
+++ b/docs/decisions/0000-template.md
@@ -1,0 +1,88 @@
+# ADR-0000: Architecture Decision Record Template
+
+**Status**: Template (not a decision itself)
+**Date**: YYYY-MM-DD
+**Author**: @your-github-handle
+
+---
+
+## Context
+
+> What is the situation or problem that motivated this decision?
+> Describe the forces at play: technical, business, organizational.
+> Be specific about constraints and requirements.
+
+## Decision
+
+> What was decided?
+> State it clearly and concisely.
+> Use active voice: "We will use X" rather than "X was chosen".
+
+## Options Considered
+
+### Option A: [Name]
+
+**Pros:**
+- ...
+
+**Cons:**
+- ...
+
+### Option B: [Name]
+
+**Pros:**
+- ...
+
+**Cons:**
+- ...
+
+## Rationale
+
+> Why was this option chosen over the alternatives?
+> Reference benchmarks, team experience, community support, or other evidence.
+> Be honest about trade-offs.
+
+## Consequences
+
+### Positive
+- ...
+
+### Negative / Trade-offs
+- ...
+
+### Risks
+- ...
+
+## Implementation Notes
+
+> Any specific implementation details, migration steps, or gotchas.
+
+## References
+
+- [Link to relevant issue, PR, or external resource]
+
+---
+
+## How to Use This Template
+
+1. Copy this file: `cp 0000-template.md NNNN-short-title.md`
+2. Fill in all sections
+3. Set Status to `Proposed`
+4. Submit as PR for team review
+5. After approval, change Status to `Accepted`
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `Proposed` | Under discussion, not yet decided |
+| `Accepted` | Team agreed, in effect |
+| `Deprecated` | No longer applicable |
+| `Superseded by ADR-NNNN` | Replaced by a newer decision |
+
+### Immutability Rule
+
+**ADRs are immutable.** Never edit an accepted ADR.
+Instead, create a new ADR that supersedes it and update the old one's status to `Superseded by ADR-NNNN`.
+
+This preserves the decision history and shows how thinking evolved over time.

--- a/docs/decisions/0001-use-biome.md
+++ b/docs/decisions/0001-use-biome.md
@@ -1,0 +1,105 @@
+# ADR-0001: Use Biome for Linting and Formatting
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Author**: @geolonia/platform
+
+---
+
+## Context
+
+Every TypeScript project needs consistent code style (formatting) and quality checks (linting).
+The traditional choice is ESLint (lint) + Prettier (format), but this combination has friction:
+- Two separate tools with separate configs, sometimes conflicting rules
+- Slow startup time (ESLint: 2-5 seconds per run)
+- Complex configuration for TypeScript strict rules
+
+We need a solution that is fast enough for Claude Code PostToolUse hooks (ms-level feedback)
+and simple enough to maintain across many repositories.
+
+## Decision
+
+We will use **Biome** as the unified linter and formatter for all new TypeScript repositories.
+
+ESLint and Prettier will **not** be used in new repositories created from this template.
+
+## Options Considered
+
+### Option A: ESLint + Prettier (current de facto standard)
+
+**Pros:**
+- Widely adopted, large ecosystem
+- Many plugins available (react, import, etc.)
+- Familiar to most developers
+
+**Cons:**
+- Two separate tools, two configs
+- Slow: ESLint startup takes 2-5 seconds
+- Config conflicts between ESLint and Prettier
+- Complex TypeScript setup requires `@typescript-eslint/parser`, `@typescript-eslint/eslint-plugin`
+
+### Option B: Biome (Rust-based all-in-one tool)
+
+**Pros:**
+- 10-25x faster than ESLint+Prettier (Rust implementation)
+- Single tool, single config (`biome.json`)
+- Built-in TypeScript support (no extra plugins)
+- Fast enough for PostToolUse hooks (Layer 1 feedback)
+- `biome migrate` command converts existing ESLint/Prettier configs
+
+**Cons:**
+- Smaller ecosystem than ESLint
+- Some ESLint plugins have no Biome equivalent (e.g., complex custom rules)
+- Newer tool (stable since 2024)
+
+### Option C: Oxlint (Rust-based lint only)
+
+**Pros:**
+- 50-100x faster than ESLint
+- Strong security ruleset
+
+**Cons:**
+- Lint only, no formatting → still needs Prettier
+- Does not eliminate the two-tool problem
+
+## Rationale
+
+Biome was chosen because:
+
+1. **Speed**: The 4-layer quality model requires ms-level feedback at Layer 1 (PostToolUse hooks).
+   ESLint's 2-5 second startup makes it unusable for this purpose. Biome runs in milliseconds.
+
+2. **Simplicity**: One tool, one config. Reduces maintenance overhead across many repos.
+
+3. **TypeScript-first**: Built-in TypeScript support without plugin configuration.
+
+4. **Future-proof**: Biome is backed by the Rome collective and has strong momentum.
+
+Oxlint's security rules can complement Biome for specific security scanning in CI (Layer 3),
+but Biome covers all daily development needs.
+
+## Consequences
+
+### Positive
+- PostToolUse hooks give instant format feedback (Layer 1)
+- Consistent formatting across all new repositories
+- Simpler dependency tree (fewer devDependencies)
+
+### Negative / Trade-offs
+- Cannot use ESLint-specific plugins (e.g., `eslint-plugin-react-hooks` for internal rules)
+- Developers must learn Biome's config format instead of ESLint's
+
+### Risks
+- If Biome lacks a rule we need, we may need to add Oxlint or a custom CI check
+
+## Implementation Notes
+
+- `biome.json` is a protected file (cannot be modified by agents via guard.sh Hook 5)
+- `noExplicitAny: error` enforces TypeScript strict mode at the lint level
+- Use `biome migrate` to convert existing ESLint/Prettier configs when adopting this template
+
+## References
+
+- [Biome documentation](https://biomejs.dev/)
+- [Harness Engineering Best Practices 2026](https://nyosegawa.github.io/posts/harness-engineering-best-practices-2026/)
+- [ADR-0002: Use Lefthook](./0002-use-lefthook.md)

--- a/docs/decisions/0002-use-lefthook.md
+++ b/docs/decisions/0002-use-lefthook.md
@@ -1,0 +1,110 @@
+# ADR-0002: Use Lefthook for Git Hooks
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Author**: @geolonia/platform
+
+---
+
+## Context
+
+Git hooks (pre-commit, pre-push) provide Layer 2 feedback in the 4-layer quality model:
+faster than CI (minutes) but slightly slower than PostToolUse hooks (milliseconds).
+
+The most common approach is Husky + lint-staged, but this has performance and configuration
+overhead. We need a solution that is fast, easy to configure, and works well with
+non-Node.js tools (like Biome and tsc).
+
+## Decision
+
+We will use **Lefthook** for Git hooks in all new TypeScript repositories.
+
+Husky and lint-staged will **not** be used in new repositories created from this template.
+
+## Options Considered
+
+### Option A: Husky + lint-staged (current de facto standard)
+
+**Pros:**
+- Very widely adopted
+- `npm install` auto-setup via `postinstall` hook
+- lint-staged runs only on staged files (efficient)
+
+**Cons:**
+- Two tools (Husky + lint-staged), two configs
+- Node.js dependent: Husky requires npm scripts for hook setup
+- lint-staged config can be complex (glob patterns for each tool)
+- Slow-ish: Node.js startup overhead on each hook run
+
+### Option B: Lefthook (Go-based hook manager)
+
+**Pros:**
+- **Single binary** (Go): No runtime dependency on Node.js
+- **Parallel execution**: Multiple commands run simultaneously
+- **Native staged-files support**: `{staged_files}` placeholder in config
+- **Simple YAML config**: `lefthook.yml` is readable and maintainable
+- **Fast**: Go binary starts faster than Node.js scripts
+- **All in one**: No need for a separate `lint-staged` tool
+
+**Cons:**
+- Less widely known than Husky
+- Requires `npx lefthook install` after cloning (vs Husky's auto-postinstall)
+- Some developers may not be familiar with it
+
+### Option C: Simple shell scripts (`.git/hooks/`)
+
+**Pros:**
+- No dependencies
+
+**Cons:**
+- Not committed to the repository (`.git/hooks/` is not versioned)
+- Each developer must set up manually
+- No parallel execution support
+
+## Rationale
+
+Lefthook was chosen because:
+
+1. **Speed**: Go binary starts faster than Node.js. Important for pre-commit hooks
+   that run on every commit.
+
+2. **Simplicity**: One tool, one `lefthook.yml`. No need for a separate `lint-staged` config.
+
+3. **Parallel execution**: `parallel: true` in `lefthook.yml` runs typecheck and lint
+   simultaneously, reducing total hook time.
+
+4. **Compatibility with non-Node tools**: Biome and tsc can be invoked directly without
+   the Node.js wrapper overhead that lint-staged adds.
+
+5. **Stage-aware**: `{staged_files}` variable passes only staged files to Biome,
+   avoiding unnecessary checks on unstaged files.
+
+## Consequences
+
+### Positive
+- Faster pre-commit hooks (parallel execution)
+- Simpler configuration (one file instead of Husky + lint-staged)
+- Works well with Biome (see ADR-0001)
+
+### Negative / Trade-offs
+- Developers must run `npx lefthook install` after cloning
+- Less community awareness than Husky
+
+### Migration for existing repos
+- Remove: `husky`, `lint-staged` from devDependencies
+- Remove: `.husky/` directory and `lint-staged` config in `package.json`
+- Add: `lefthook` devDependency
+- Create: `lefthook.yml`
+- Run: `npx lefthook install`
+
+## Implementation Notes
+
+- `lefthook.yml` is a protected file (cannot be modified by agents via guard.sh Hook 5)
+- After cloning this template, run: `pnpm install && npx lefthook install`
+- The pre-push hook runs tests, so ensure Vitest is set up before pushing
+
+## References
+
+- [Lefthook documentation](https://github.com/evilmartians/lefthook)
+- [Harness Engineering Best Practices 2026](https://nyosegawa.github.io/posts/harness-engineering-best-practices-2026/)
+- [ADR-0001: Use Biome](./0001-use-biome.md)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,28 @@
+# Lefthook configuration
+# See: https://github.com/evilmartians/lefthook
+#
+# WHY Lefthook: Go製シングルバイナリで高速。並列実行対応。
+# Node.js 外のツール（Biome等）との相性が良い。
+# See: docs/decisions/0002-use-lefthook.md
+
+pre-commit:
+  parallel: true
+  commands:
+    format:
+      glob: "*.{ts,js,json}"
+      run: npx biome format --write {staged_files}
+      stage_fixed: true
+    lint:
+      glob: "*.{ts,js}"
+      run: npx biome check {staged_files}
+    typecheck:
+      run: npx tsc --noEmit
+
+pre-push:
+  commands:
+    typecheck:
+      run: npx tsc --noEmit
+    lint:
+      run: npx biome check .
+    test:
+      run: npx vitest run

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@geolonia/template-library-name",
+  "version": "0.0.1",
+  "description": "Replace with your library description",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@types/node": "^22.0.0",
+    "lefthook": "^1.9.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1219 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      lefthook:
+        specifier: ^1.9.0
+        version: 1.13.6
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.15)
+
+packages:
+
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  lefthook-darwin-arm64@1.13.6:
+    resolution: {integrity: sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.13.6:
+    resolution: {integrity: sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.13.6:
+    resolution: {integrity: sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.13.6:
+    resolution: {integrity: sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.13.6:
+    resolution: {integrity: sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.13.6:
+    resolution: {integrity: sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.13.6:
+    resolution: {integrity: sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.13.6:
+    resolution: {integrity: sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.13.6:
+    resolution: {integrity: sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.13.6:
+    resolution: {integrity: sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.13.6:
+    resolution: {integrity: sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g==}
+    hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.15':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.15)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  js-tokens@9.0.1: {}
+
+  lefthook-darwin-arm64@1.13.6:
+    optional: true
+
+  lefthook-darwin-x64@1.13.6:
+    optional: true
+
+  lefthook-freebsd-arm64@1.13.6:
+    optional: true
+
+  lefthook-freebsd-x64@1.13.6:
+    optional: true
+
+  lefthook-linux-arm64@1.13.6:
+    optional: true
+
+  lefthook-linux-x64@1.13.6:
+    optional: true
+
+  lefthook-openbsd-arm64@1.13.6:
+    optional: true
+
+  lefthook-openbsd-x64@1.13.6:
+    optional: true
+
+  lefthook-windows-arm64@1.13.6:
+    optional: true
+
+  lefthook-windows-x64@1.13.6:
+    optional: true
+
+  lefthook@1.13.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.13.6
+      lefthook-darwin-x64: 1.13.6
+      lefthook-freebsd-arm64: 1.13.6
+      lefthook-freebsd-x64: 1.13.6
+      lefthook-linux-arm64: 1.13.6
+      lefthook-linux-x64: 1.13.6
+      lefthook-openbsd-arm64: 1.13.6
+      lefthook-openbsd-x64: 1.13.6
+      lefthook-windows-arm64: 1.13.6
+      lefthook-windows-x64: 1.13.6
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@3.2.4(@types/node@22.19.15):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.1(@types/node@22.19.15):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.19.15):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.19.15)
+      vite-node: 3.2.4(@types/node@22.19.15)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/scripts/hooks/guard.sh
+++ b/scripts/hooks/guard.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# guard.sh — Claude Code PreToolUse hook for Bash tool
+# Generic version: Hook 2 (destructive ops), Hook 3 (main branch protection),
+# Hook 4 (push-before-lint/typecheck), Hook 5 (config file protection)
+#
+# Reads JSON from stdin: {"tool_name": "Bash", "tool_input": {"command": "..."}}
+# exit 0 = allow, exit 2 = block (stderr shown as error message)
+
+set -euo pipefail
+
+# Read JSON from stdin
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+# ============================================================
+# Helper: resolve effective working directory from cd in command
+# ============================================================
+resolve_git_dir() {
+  local cmd="$1"
+  local cd_target
+  cd_target=$(echo "$cmd" | grep -oP 'cd\s+\K("[^"]+"|[^\s&;|]+)' | tail -1 | tr -d '"')
+  if [[ -n "$cd_target" && -d "$cd_target" ]]; then
+    echo "$cd_target"
+  else
+    echo "."
+  fi
+}
+
+GIT_TARGET_DIR=$(resolve_git_dir "$COMMAND")
+
+# ============================================================
+# Helper: detect git subcommand invocation
+# ============================================================
+has_git_subcmd() {
+  local cmd="$1"
+  local subcmd="$2"
+  echo "$cmd" | grep -qE "git\s+$subcmd\b" && return 0
+  echo "$cmd" | grep -qE "/git\s+$subcmd\b" && return 0
+  echo "$cmd" | grep -qE "(command|env)\s+git\s+$subcmd\b" && return 0
+  echo "$cmd" | grep -qE '\(\)\s*\{[^}]*git\b' && echo "$cmd" | grep -qE "\b$subcmd\b" && return 0
+  echo "$cmd" | grep -qE '\w+=git(\s|;|&|$)' && echo "$cmd" | grep -qE "\b$subcmd\b" && return 0
+  echo "$cmd" | grep -qiE "\w+=$subcmd(\s|;|&|\"|$)" && echo "$cmd" | grep -qE 'git\s+\$' && return 0
+  return 1
+}
+
+# ============================================================
+# Hook 2: 破壊的操作ガード (D001-D008)
+# WHY: エージェントによる不可逆な操作を防ぐ安全ネット
+# ============================================================
+
+# D001: rm -rf on critical paths
+if echo "$COMMAND" | grep -qE 'rm\s+-rf\s+(/\*?$|/mnt/\*|/home/\*|~(/|$| ))' || \
+   echo "$COMMAND" | grep -qE 'rm\s+-rf\s+~$'; then
+  echo "❌ Destructive operation blocked: rm -rf on critical path (D001)" >&2
+  exit 2
+fi
+
+# D003: git push --force / -f (without --force-with-lease)
+if has_git_subcmd "$COMMAND" "push" && echo "$COMMAND" | grep -qE '\-\-force\b' && ! echo "$COMMAND" | grep -q 'force-with-lease'; then
+  echo "❌ Destructive operation blocked: git push --force (D003). Use --force-with-lease instead." >&2
+  exit 2
+fi
+if has_git_subcmd "$COMMAND" "push" && echo "$COMMAND" | grep -qE '(^|\s)-f\b'; then
+  echo "❌ Destructive operation blocked: git push -f (D003). Use --force-with-lease instead." >&2
+  exit 2
+fi
+
+# D004: git reset --hard / git checkout -- . / git restore . / git clean -f
+if has_git_subcmd "$COMMAND" "reset" && echo "$COMMAND" | grep -q '\-\-hard'; then
+  echo "❌ Destructive operation blocked: git reset --hard (D004). Use git stash instead." >&2
+  exit 2
+fi
+if has_git_subcmd "$COMMAND" "checkout" && echo "$COMMAND" | grep -qE '\-\-\s+\.'; then
+  echo "❌ Destructive operation blocked: git checkout -- . (D004)" >&2
+  exit 2
+fi
+if echo "$COMMAND" | grep -qE 'git\s+restore\s+\.'; then
+  echo "❌ Destructive operation blocked: git restore . (D004)" >&2
+  exit 2
+fi
+if echo "$COMMAND" | grep -qE 'git\s+clean\s+-f'; then
+  echo "❌ Destructive operation blocked: git clean -f (D004). Run git clean -n first." >&2
+  exit 2
+fi
+
+# D005: chmod -R / chown -R on system paths
+if echo "$COMMAND" | grep -qE '(chmod|chown)\s+-R\b' && \
+   echo "$COMMAND" | grep -qE '\s/(etc|usr|bin|sbin|lib|lib64|var|opt|root|sys|proc|boot|dev|srv|mnt|snap)(/| |$)'; then
+  echo "❌ Destructive operation blocked: chmod/chown -R on system path (D005)" >&2
+  exit 2
+fi
+
+# D006: kill/killall/pkill
+if echo "$COMMAND" | grep -qE '\b(killall|pkill)\b'; then
+  echo "❌ Destructive operation blocked: killall/pkill (D006)" >&2
+  exit 2
+fi
+
+# D007: mkfs/dd if=/fdisk
+if echo "$COMMAND" | grep -qE '\b(mkfs|fdisk)\b'; then
+  echo "❌ Destructive operation blocked: mkfs/fdisk (D007)" >&2
+  exit 2
+fi
+if echo "$COMMAND" | grep -qE 'dd\s+if='; then
+  echo "❌ Destructive operation blocked: dd if= (D007)" >&2
+  exit 2
+fi
+
+# D008: pipe-to-shell patterns
+if echo "$COMMAND" | grep -qE '(curl|wget)\s+.*\|\s*(bash|sh)'; then
+  echo "❌ Destructive operation blocked: curl/wget|bash/sh pattern (D008)" >&2
+  exit 2
+fi
+
+# ============================================================
+# Hook 3: main ブランチ保護
+# WHY: main への直接コミット/プッシュは意図しない変更を本番反映するリスクがある
+# ============================================================
+if has_git_subcmd "$COMMAND" "commit" || has_git_subcmd "$COMMAND" "push"; then
+  CURRENT_BRANCH=$(git -C "$GIT_TARGET_DIR" branch --show-current 2>/dev/null || echo "")
+  if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+    echo "❌ Direct commit/push to main/master is not allowed. Please create a branch." >&2
+    exit 2
+  fi
+fi
+
+# ============================================================
+# Hook 4: push 前 lint/typecheck チェック
+# WHY: CI 失敗を防ぐ。ローカルで早期検出する方が修正コストが低い
+# ============================================================
+if has_git_subcmd "$COMMAND" "push"; then
+  PKG_JSON=$(find "$GIT_TARGET_DIR" -maxdepth 2 -name "package.json" ! -path "*/node_modules/*" 2>/dev/null | head -1)
+  if [[ -n "$PKG_JSON" ]]; then
+    PKG_DIR=$(dirname "$PKG_JSON")
+    HAS_TYPECHECK=$(jq -r '.scripts.typecheck // ""' "$PKG_JSON")
+    HAS_LINT=$(jq -r '.scripts.lint // ""' "$PKG_JSON")
+
+    if [[ -n "$HAS_TYPECHECK" || -n "$HAS_LINT" ]]; then
+      cd "$PKG_DIR"
+      FAILED=0
+      if [[ -n "$HAS_TYPECHECK" ]]; then
+        if ! npm run typecheck --silent 2>/dev/null; then
+          FAILED=1
+        fi
+      fi
+      if [[ -n "$HAS_LINT" ]]; then
+        if ! npm run lint --silent 2>/dev/null; then
+          FAILED=1
+        fi
+      fi
+      if [[ $FAILED -eq 1 ]]; then
+        echo "❌ typecheck/lint errors detected. Please fix before pushing." >&2
+        exit 2
+      fi
+    fi
+  fi
+fi
+
+# ============================================================
+# Hook 5: 設定ファイル保護
+# WHY: エージェントがlintエラーを修正する代わりに設定を緩めることを防ぐ
+# ============================================================
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+if [[ -n "$FILE_PATH" ]]; then
+  PROTECTED_PATTERNS=(
+    "biome.json"
+    "tsconfig.json"
+    "tsconfig.*.json"
+    "lefthook.yml"
+    ".github/workflows/"
+    "catalog-info.yaml"
+    "CODEOWNERS"
+  )
+  for pattern in "${PROTECTED_PATTERNS[@]}"; do
+    if [[ "$FILE_PATH" == *"$pattern"* ]]; then
+      echo "❌ Configuration file '$FILE_PATH' is protected and cannot be modified by agents." >&2
+      echo "   WHY: Config files define code quality standards. Agent modifications could weaken them." >&2
+      echo "   FIX: Modify this file manually after team review (ADR required for significant changes)." >&2
+      exit 2
+    fi
+  done
+fi
+
+exit 0

--- a/scripts/hooks/post-tool-format.sh
+++ b/scripts/hooks/post-tool-format.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# post-tool-format.sh — Claude Code PostToolUse hook
+# Automatically formats and lints files after Write/Edit operations.
+# WHY: Provides ms-level feedback (Layer 1). Biome/Oxlint are Rust-based and
+#      start in milliseconds, unlike ESLint which takes seconds.
+#
+# Usage: Called automatically by Claude Code via .claude/settings.json
+# Input: FILE_PATH environment variable (set by Claude Code)
+
+set -euo pipefail
+
+FILE_PATH="${1:-${FILE_PATH:-}}"
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Only process TypeScript/JavaScript files
+if [[ ! "$FILE_PATH" =~ \.(ts|tsx|js|jsx|mjs|cjs)$ ]]; then
+  exit 0
+fi
+
+# Only process files that exist
+if [[ ! -f "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+FAILED=0
+ERRORS=""
+
+# Step 1: Auto-format with Biome
+if command -v npx &>/dev/null; then
+  if ! npx biome format --write "$FILE_PATH" 2>/dev/null; then
+    FAILED=1
+    ERRORS+="[biome format] Failed to format $FILE_PATH\n"
+  fi
+
+  # Step 2: Lint check with Biome
+  if ! npx biome check "$FILE_PATH" 2>&1; then
+    FAILED=1
+    ERRORS+="[biome check] Lint errors in $FILE_PATH\n"
+  fi
+fi
+
+if [[ $FAILED -eq 1 ]]; then
+  echo -e "$ERRORS" >&2
+  exit 1
+fi
+
+exit 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @geolonia/template-library-name
+ *
+ * Replace this file with your library's entry point.
+ */
+
+/**
+ * Example: replace with your exported functions/classes/types.
+ */
+export function hello(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { hello } from "../src/index.js";
+
+describe("hello", () => {
+  it("returns greeting with name", () => {
+    expect(hello("World")).toBe("Hello, World!");
+  });
+
+  it("returns greeting with empty string", () => {
+    expect(hello("")).toBe("Hello, !");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
Closes #1

## Summary

geolonia-template-library の初期テンプレートを構築しました。TypeScript ライブラリ開発の標準構成を提供します。

## Changes

### Core Tooling
- **Biome** — lint + format を一元化 (ESLint+Prettier 代替, 10-25x 高速) → [ADR-0001](docs/decisions/0001-use-biome.md)
- **Lefthook** — pre-commit/pre-push hooks (Go 製バイナリ, 高速) → [ADR-0002](docs/decisions/0002-use-lefthook.md)
- **Vitest** — テストランナー
- **TypeScript 5 strict** — `any` 禁止, null チェック厳格化

### Claude Code Hooks
- `scripts/hooks/guard.sh` — PreToolUse Hook 2-5 (破壊的操作ブロック + main保護 + 設定ファイル保護)
- `scripts/hooks/post-tool-format.sh` — PostToolUse 自動フォーマット
- `.claude/settings.json` — hooks 設定
- `.claude/skills/code-review-expert/SKILL.md` — 汎用版スキル

### Documentation
- `README.md` — Getting Started, ツール説明, guard.sh説明, CI/CD, catalog-info.yaml記入ガイド, FAQ
- `AGENTS.md` — エージェント共通指示 (AAIF 標準)
- `CLAUDE.md` — Claude Code 固有設定 (50行以内)
- `docs/decisions/0000-template.md` — ADR テンプレート
- `docs/decisions/0001-use-biome.md` — Biome 採用理由
- `docs/decisions/0002-use-lefthook.md` — Lefthook 採用理由

### Compliance
- `catalog-info.yaml` — Backstage + ISMS アノテーション (各フィールドにコメント付き)
- `.github/CODEOWNERS` — 設定ファイルへの platform チームレビュー必須化
- `.github/dependabot.yml` — npm + GitHub Actions 自動更新
- `.github/workflows/ci.yml` — typecheck + lint + test + build + npm publish

## Test plan

- [x] `pnpm run typecheck` → PASS
- [x] `pnpm run lint` → PASS
- [x] `pnpm run test` → 2 tests PASS
- [x] `pnpm run build` → PASS
- [x] `/code-review-expert --auto` → P0: 0, P1: 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * プロジェクトの初期スキャフォルディングとTypeScript対応を追加。

* **Documentation**
  * README、セットアップガイド、アーキテクチャ決定記録、Claude統合ワークフロー、開発エージェント向けガイドラインを新規追加。

* **Chores**
  * コード品質ツール（Biome、Lefthook、Vitest）を構成。
  * GitHub Actions によるCI/CD自動化とDependabotによる依存関係管理を設定。
  * Git フック、コードレビューワークフロー、セキュリティガードレール を実装。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->