### PR TITLE
docs: template-manifest.yaml + Getting Started rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,29 @@ Geolonia TypeScript プロジェクトのベーステンプレート。
 
 ## Getting Started
 
-### 1. Clone & Rename
+### 方法 1: 新規リポジトリ（GitHub UI）
+
+1. このリポジトリの **"Use this template"** → **"Create a new repository"** をクリック
+2. リポジトリ名と説明を入力して作成
+3. クローンしてカスタマイズ（下記「カスタマイズ」参照）
+
+### 方法 2: 新規リポジトリ（CLI）
 
 ```bash
-git clone https://github.com/geolonia/geolonia-template.git your-project-name
-cd your-project-name
-rm -rf .git
-git init
-git checkout -b main
+gh repo create my-project --template geolonia/geolonia-template --public
+gh repo clone my-project
+cd my-project
 ```
 
-### 2. Customize
+### 方法 3: 既存リポジトリに適用
+
+```bash
+npx @geolonia/template apply
+```
+
+または、AI エージェントが `template-manifest.yaml` を読んで必要なファイルを適用できます。
+
+### カスタマイズ
 
 | ファイル | 変更箇所 |
 |--------|--------|
@@ -31,7 +43,7 @@ git checkout -b main
 - **フロントエンド**: Vite, React, TailwindCSS 等を追加
 - **API**: Lambda handler, Express/Hono 等を追加
 
-### 3. Setup
+### セットアップ
 
 ```bash
 pnpm install

--- a/template-manifest.yaml
+++ b/template-manifest.yaml
@@ -1,0 +1,118 @@
+# template-manifest.yaml
+#
+# AI エージェントおよび CLI ツール向けのテンプレート適用ガイド。
+# 新規・既存リポジトリへの適用時に、このファイルを読んで判断する。
+#
+# 使い方:
+#   新規リポ（GitHub UI）: "Use this template" ボタン
+#   新規リポ（CLI）:       gh repo create my-project --template geolonia/geolonia-template
+#   既存リポ（CLI）:       npx @geolonia/template apply
+#   既存リポ（AI）:        このファイルを読んで必要なファイルを適用
+
+version: 1
+
+files:
+  # ── 必須: AI エージェントの安全性と品質の基盤 ──
+  required:
+    - path: scripts/hooks/guard.sh
+      purpose: "破壊的操作ブロック + main 保護 + push 前チェック"
+
+    - path: scripts/hooks/post-tool-format.sh
+      purpose: "ファイル書き込み後の自動フォーマット"
+
+    - path: .claude/settings.json
+      purpose: "Claude Code hooks 設定"
+
+    - path: CLAUDE.md
+      purpose: "Claude Code 固有設定"
+      merge_strategy: "既存があれば末尾に追記"
+
+    - path: AGENTS.md
+      purpose: "エージェント共通指示"
+      merge_strategy: "既存があれば末尾に追記"
+
+  # ── 推奨: 衝突がなければ適用 ──
+  recommended:
+    - path: biome.json
+      purpose: "Lint + Format (ESLint + Prettier の代替)"
+      conflicts_with: [".eslintrc*", ".eslintrc.js", ".prettierrc*", ".prettierrc.js"]
+      migration: "npx @biomejs/biome migrate で ESLint 設定を変換可能"
+
+    - path: lefthook.yml
+      purpose: "Git hooks (pre-commit: format + lint, pre-push: typecheck + test)"
+      conflicts_with: [".husky/", ".lintstagedrc*"]
+
+    - path: catalog-info.yaml
+      purpose: "Backstage + ISMS メタデータ"
+
+    - path: .github/CODEOWNERS
+      purpose: "レビュー必須設定"
+      merge_strategy: "既存があればスキップ"
+
+    - path: .github/dependabot.yml
+      purpose: "依存関係自動更新"
+      merge_strategy: "既存があればスキップ"
+
+    - path: .github/workflows/ci.yml
+      purpose: "CI パイプライン (typecheck + lint + test + build)"
+      merge_strategy: "既存があればスキップ"
+
+  # ── 任意: 必要に応じて適用 ──
+  optional:
+    - path: docs/decisions/0000-template.md
+      purpose: "ADR テンプレート"
+
+    - path: .claude/skills/code-review-expert/SKILL.md
+      purpose: "コードレビュースキル"
+
+# ── プレースホルダー ──
+# 適用時にプロジェクト情報で置換する
+placeholders:
+  "{{PROJECT_NAME}}":
+    description: "リポジトリ名（小文字・ハイフン区切り）"
+    example: "my-awesome-lib"
+    found_in: [catalog-info.yaml]
+
+  "{{DESCRIPTION}}":
+    description: "プロジェクトの1行説明"
+    example: "A TypeScript library for geocoding"
+    found_in: [catalog-info.yaml]
+
+  "{{DISPLAY_NAME}}":
+    description: "人が読む表示名（日本語可）"
+    example: "Geolonia Geocoder"
+    found_in: [catalog-info.yaml]
+
+  "{{TEAM}}":
+    description: "Backstage チームスラッグ"
+    example: "platform"
+    found_in: [catalog-info.yaml, .github/CODEOWNERS]
+
+  "{{SYSTEM}}":
+    description: "Backstage システム名"
+    example: "geolonia-developer-platform"
+    found_in: [catalog-info.yaml]
+
+  "{{TYPE}}":
+    description: "コンポーネント種別"
+    example: "library"
+    values: [library, service, website, documentation]
+    found_in: [catalog-info.yaml]
+
+# ── 既存リポへの適用手順（AI エージェント向け） ──
+apply_to_existing:
+  steps:
+    - "template-manifest.yaml を読む"
+    - "required ファイルをコピー（merge_strategy に従う）"
+    - "recommended ファイルについて conflicts_with を検査"
+    - "衝突がなければ recommended ファイルをコピー"
+    - "衝突があれば警告し、migration ヒントを提示"
+    - "placeholders を実際の値で置換"
+    - "devDependencies を追加: @biomejs/biome, lefthook, vitest, typescript, @types/node"
+    - "package.json scripts を追加: build, typecheck, lint, lint:fix, format, test"
+    - "pnpm install && npx lefthook install を実行"
+
+  do_not_touch:
+    - "既存の src/ や tests/ のコードは変更しない"
+    - "既存の package.json の name, version, dependencies は変更しない"
+    - "既存の tsconfig.json がある場合は strict: true の追加のみ提案（強制しない）"


### PR DESCRIPTION
## Summary
- Add `template-manifest.yaml` — structured guide for AI agents and CLI tools to apply template to existing repos
- Rewrite Getting Started section with three application methods: GitHub UI template button, `gh repo create --template`, and `npx @geolonia/template apply`
- Remove old Clone & Rename approach (no more `rm -rf .git`)

## Test plan
- [ ] Verify `template-manifest.yaml` is valid YAML and references correct file paths
- [ ] Verify README renders correctly on GitHub
- [ ] Verify "Use this template" button appears on repo page (already enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * セットアップ手順を拡張し、複数の初期化方法（UI テンプレート利用、CLI、既存リポジトリへの適用）に対応しました。
  * カスタマイズガイドを新たに追加し、設定ファイルの変更対応状況を明示しました。

* **新機能**
  * AI エージェントと CLI ツール向けのテンプレート適用ガイダンスを導入しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->