### PR TITLE
docs: README の /init-project 配置修正 + Skills セクション追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `secret-protection.sh.disabled`: Bash bypass detection strengthened (grep/awk/sed/source/redirect/command substitution)
 - `secret-protection.sh.disabled`: Extracted `get_file_path()` function to eliminate duplication
 - `.claude/skills/code-review-expert/SKILL.md`: Added `text` language specifier to compact template code block
+- `README.md`: Renamed `/init-project` section from "カスタマイズ" to "初期セットアップ" to clarify it is a post-install step
+- `README.md`: Expanded `.claude/skills/` in Directory Structure to show `init-project/` and `code-review-expert/`
 
 ### Added
+- `README.md`: New **Skills** section listing `/init-project` and `/code-review-expert` with descriptions
+
+
 - Initial template structure for Geolonia TypeScript projects
 - TypeScript 5 strict mode configuration (`tsconfig.json`)
 - Biome for linting and formatting (`biome.json`) — see ADR-0001

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ AI エージェントに以下のように指示してください:
 
 > **Note**: CLI での適用（`npx @geolonia/template apply`）は未実装です。進捗は [#10](https://github.com/geolonia/geolonia-template/issues/10) を参照してください。
 
-### カスタマイズ（`/init-project`）
+### 初期セットアップ（`/init-project`）
 
-Claude Code で `/init-project` を実行すると、対話的にプロジェクト情報を入力できます:
+テンプレートを適用したら、Claude Code で `/init-project` を実行してプロジェクト情報を入力します:
 
 ```
 > /init-project
@@ -91,6 +91,17 @@ Claude Code で `/init-project` を実行すると、対話的にプロジェク
 - **フロントエンド**: Vite, React, TailwindCSS 等を追加
 - **API**: Lambda handler, Express/Hono 等を追加
 
+## Skills
+
+Claude Code のスラッシュコマンドとして呼び出せるスキルが同梱されています。
+
+| スキル | 呼び出し方 | 概要 |
+|-------|-----------|------|
+| `/init-project` | `> /init-project` | テンプレート適用後の初期セットアップ。プロジェクト名・チーム名等のプレースホルダーを対話的に置換。何度でも実行可能 |
+| `/code-review-expert` | `> /code-review-expert --auto` | SOLID 原則・セキュリティ・品質を構造的にレビュー。`--auto` で P0/P1 を自動修正し push ブロック解除マーカーを生成 |
+
+スキルの実体は `.claude/skills/{skill-name}/SKILL.md` に格納されています。
+
 ## What's Included
 
 ### 4層品質モデル
@@ -123,7 +134,9 @@ Claude Code で `/init-project` を実行すると、対話的にプロジェク
 .
 ├── .claude/                    # Claude Code 設定
 │   ├── settings.json           #   hooks 設定
-│   └── skills/                 #   スキル
+│   └── skills/                 #   スキル（/コマンドで呼び出し可能）
+│       ├── init-project/       #     /init-project — 初期セットアップ
+│       └── code-review-expert/ #     /code-review-expert — コードレビュー
 ├── .github/                    # GitHub 設定
 │   ├── workflows/ci.yml        #   CI
 │   ├── CODEOWNERS              #   レビュー必須設定


### PR DESCRIPTION
## Summary

- `/init-project` セクションを「カスタマイズ」から「初期セットアップ」に改称し、テンプレート適用直後の必須ステップであることを明確化
- **Skills** セクションを新設し、`/init-project` と `/code-review-expert` の概要を一覧化
- Directory Structure で `.claude/skills/` の中身（`init-project/`、`code-review-expert/`）を展開

Closes #14

## Test plan

- [ ] README.md の `/init-project` セクションが「初期セットアップ」として配置されていること
- [ ] Skills セクションが Getting Started と What's Included の間に存在すること
- [ ] Directory Structure に `.claude/skills/` の子ディレクトリが展開されていること
- [ ] CI PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * READMEの「カスタマイズ」表記を「初期セットアップ」に改称し、/init-projectはテンプレート適用後に実行する旨を明記
  * 新しい「Skills」節を追加し、/init-project（初期セットアップ）と/code-review-expert（構造化コードレビュー）を説明
  * .claude/skills 配下のディレクトリ表示を拡張し、SKILL.md 保存場所を明記
  * 表現や参照の文言を調整
<!-- end of auto-generated comment: release notes by coderabbit.ai -->